### PR TITLE
Adding optional / simple policy result caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,4 @@ main.py
 
 # Files using default policy suffix
 *.policy.json
+*.cache.json

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # MADI
+
 Dead simple JSON policy engine.
 
 ## Usage
@@ -8,14 +9,17 @@ Policies are defined in JSON following the following format.
 ```json
 // test-policy.policy.json
 {
-  "$schema": "https://raw.githubusercontent.com/stephen-bunn/madi/refs/heads/main/schemas/v1/MadiPolicy.json"
+  "$schema": "https://raw.githubusercontent.com/stephen-bunn/madi/refs/heads/main/schemas/v1/MadiPolicy.json",
   "ref": "PolicyReference",
+  "uid": "0ae1ef57-45b4-4725-9555-19cd273836c4",
   "rules": [
     {
       "ref": "RuleReference",
+      "uid": "4a46a22a-5954-42b0-9238-390967b5d1cf",
       "action": "DENY", // DENY or ALLOW
       "select": "test", // A JMESPath expression to select data from the input <https://jmespath.org/>
-      "schema": { // A JSONSchema (draft-07) to validate the selected data <https://json-schema.org/>
+      "schema": {
+        // A JSONSchema (draft-07) to validate the selected data <https://json-schema.org/>
         "type": "string"
       }
     }
@@ -25,7 +29,6 @@ Policies are defined in JSON following the following format.
 
 This policy is loaded into memory and some provided input dictionary is evaluated against this policy.
 Policy rules are evaluated in order, and the first rule to match the input dictionary will determine the outcome.
-
 
 ```python
 from madi import validate_policy_file
@@ -47,9 +50,11 @@ Policies can exit immediately if any `ALLOW` rule is matched.
 {
   "$schema": "https://raw.githubusercontent.com/stephen-bunn/madi/refs/heads/main/schemas/v1/MadiPolicy.json",
   "ref": "PolicyReference",
+  "uid": "b727732c-4a3c-4f17-b0c7-fc1fccbc95c9",
   "rules": [
     {
       "ref": "RuleReference",
+      "uid": "3eb7816d-ecb5-452c-897a-c01628192bcd",
       "action": "ALLOW",
       "select": "test",
       "schema": {
@@ -58,6 +63,7 @@ Policies can exit immediately if any `ALLOW` rule is matched.
     },
     {
       "ref": "RuleReference",
+      "uid": "9f356f7c-0cb0-4eee-aaaa-3e9a1d7d760c",
       "action": "DENY",
       "select": "test",
       "schema": {
@@ -88,4 +94,42 @@ from madi import validate_policy_dir
 # By default, any files matching the pattern `*.policy.json` will be loaded.
 # You can customize this suffix by passing in the `suffix` parameter.
 validate_policy_dir("path/to/policies", {"test": "selection"}, suffix=".json")
+```
+
+## Cache
+
+The `PolicyCache` class allows caching policy validation results to avoid redundant evaluations of the same policy and payload combinations.
+
+```python
+from madi import PolicyCache, validate_policy_file, validate_policy_dir
+
+# Create a cache instance with an optional TTL (in seconds)
+cache = PolicyCache(ttl=3600)  # Cache entries expire after 1 hour
+
+# Use cache with single policy file validation
+validate_policy_file(
+    "test-policy.policy.json",
+    {"test": "selection"},
+    cache=cache
+)
+
+# Cache results can be persisted to disk
+with open("policy-cache.json", "wb") as f:
+    cache.to_file(f)
+
+# And loaded back
+with open("policy-cache.json", "rb") as f:
+    cache = PolicyCache.from_file(f)
+```
+
+The cache uses a combination of the policy fingerprint and payload to create unique keys. You can control the fingerprint generation using the `fingerprint_policy` parameter:
+
+- `"fast"`: Uses only policy UID and rule UIDs (faster but less precise)
+- `"full"`: Uses entire policy content (slower but more precise)
+
+```python
+cache = PolicyCache(
+    ttl=3600,
+    fingerprint_policy="full"  # or "fast"
+)
 ```

--- a/schemas/v1/MadiPolicy.json
+++ b/schemas/v1/MadiPolicy.json
@@ -5,10 +5,15 @@
   "definitions": {
     "rule": {
       "type": "object",
-      "required": ["ref", "action", "select", "schema"],
+      "required": ["ref", "uid", "action", "select", "schema"],
       "properties": {
         "ref": {
           "description": "A identifying reference to this rule; preferably a unique identifier.",
+          "type": "string",
+          "minLength": 1
+        },
+        "uid": {
+          "description": "A unique identifier for the rule; preferably a UUID.",
           "type": "string",
           "minLength": 1
         },
@@ -38,7 +43,7 @@
     }
   },
   "type": "object",
-  "required": ["ref", "rules"],
+  "required": ["ref", "uid", "rules"],
   "properties": {
     "v": {
       "description": "The version identifier of the policy schema.",
@@ -47,6 +52,11 @@
     },
     "ref": {
       "description": "A identifying reference to this policy; preferably a unique identifier.",
+      "type": "string",
+      "minLength": 1
+    },
+    "uid": {
+      "description": "A unique identifier for the policy; preferably a UUID.",
       "type": "string",
       "minLength": 1
     },

--- a/src/madi/cache.py
+++ b/src/madi/cache.py
@@ -1,33 +1,83 @@
 import time
 from hashlib import sha1
 from io import BufferedReader, BufferedWriter
-from pathlib import Path
 from typing import Literal, NotRequired, TypedDict
 
-from attr import define, field
+from attr import define, field, validators
 from msgspec import json
 
 from madi.types import Policy, PolicyAction, PolicyRule
 
 type FingerprintPolicy = Literal["fast", "full"]
+"""
+The fingerprint policy determines how much information is included in the fingerprint.
+
+    * `fast` includes only the policy ID and the policy's rules.
+        This means that if a policy rule's `select` or `selection` is updated,
+        you should also update the rule's `uid` to avoid potential false positive cache hits.
+    * `full` includes the policy ID, the policy's rules, and the policy's actions.
+        This avoids potential false positive cache hits as it includes the entire policy state in
+        the fingerprint generation, but may be slower to calculate as it requires that we serialize
+        and hash the entire policy for every fingerprint calculation.
+"""
+
+FINGERPRINT_POLICIES: set[FingerprintPolicy] = {"fast", "full"}
+"""The set of all available fingerprint policies."""
+
 DEFAULT_FINGERPRINT_POLICY: FingerprintPolicy = "fast"
+"""The default fingerprint policy."""
 
 
 class PolicyCacheEntry(TypedDict):
+    """Represents a cached policy result."""
+
     rule: PolicyRule
+    """The policy rule that was evaluated to get the `action`."""
+
     action: PolicyAction
+    """The resulting policy action from the policy rule evaluation."""
+
     select: NotRequired[str]
+    """The evaluated policy rule's selection criteria."""
+
     selection: NotRequired[dict]
+    """The evaluated policy rule's selection criteria."""
+
     message: NotRequired[str]
+    """The evaluation message associated with the policy rule evaluation."""
+
     ttl: NotRequired[int]
+    """The time-to-live in seconds for the created cache entry."""
+
     timestamp: NotRequired[float]
+    """The unix timestamp when the cache entry was created."""
 
 
 @define
 class PolicyCache:
-    ttl: int | None = field(default=None)
-    fingerprint_policy: FingerprintPolicy = field(default=DEFAULT_FINGERPRINT_POLICY)
-    _result_cache: dict[str, PolicyCacheEntry] = field(factory=dict, repr=False, init=False)
+    """A cache for policy results."""
+
+    ttl: int | None = field(
+        default=None,
+        validator=validators.optional(
+            validators.and_(validators.instance_of(int), validators.ge(0))
+        ),
+    )
+    """Time-to-live in seconds for created cache entries."""
+
+    fingerprint_policy: FingerprintPolicy = field(
+        default=DEFAULT_FINGERPRINT_POLICY,
+        validator=validators.in_(FINGERPRINT_POLICIES),
+    )
+    """Fingerprint policy used to identify policy rules in cache entries."""
+
+    cache: dict[str, PolicyCacheEntry] = field(factory=dict, repr=False, init=False)
+
+    @property
+    def size(self) -> int:
+        """The number of entries in the cache."""
+
+        return len(self.cache)
 
     @classmethod
     def from_file(
@@ -36,18 +86,20 @@ class PolicyCache:
         ttl: int | None = None,
         fingerprint_policy: FingerprintPolicy = DEFAULT_FINGERPRINT_POLICY,
     ) -> "PolicyCache":
-        cache = cls(ttl=ttl, fingerprint_policy=fingerprint_policy)
-        cache._result_cache = json.decode(file_io.read())
-        return cache
+        """Load a saved policy cache from an open file."""
+
+        policy_cache = cls(ttl=ttl, fingerprint_policy=fingerprint_policy)
+        policy_cache.cache = json.decode(file_io.read())
+        return policy_cache
 
     def to_file(self, file_io: BufferedWriter):
-        file_io.write(json.encode(self._result_cache))
+        """Write the policy cache to an open file."""
 
-    def to_filepath(self, filepath: Path):
-        with filepath.open("wb") as file_io:
-            file_io.write(json.encode(self._result_cache))
+        file_io.write(json.encode(self.cache))
 
     def _build_policy_fingerprint(self, policy: Policy) -> bytes:
+        """Build a identification fingerprint for a policy."""
+
         if self.fingerprint_policy == "full":
             return sha1(json.encode(policy, order="sorted")).digest()
 
@@ -56,6 +108,8 @@ class PolicyCache:
         ).digest()
 
     def _build_cache_key(self, policy: Policy, payload: dict) -> str:
+        """Build a cache key for a policy and payload."""
+
         return sha1(
             self._build_policy_fingerprint(policy) + json.encode(payload, order="sorted")
         ).hexdigest()
@@ -69,6 +123,8 @@ class PolicyCache:
         message: str | None = None,
         ttl: int | None = None,
     ) -> PolicyCacheEntry:
+        """Build a cache entry for a policy and payload."""
+
         cache_entry: PolicyCacheEntry = {"rule": rule, "action": action}
         if select is not None and selection is not None:
             cache_entry = {**cache_entry, "select": select, "selection": selection}
@@ -82,11 +138,15 @@ class PolicyCache:
         return cache_entry
 
     def clear(self):
-        self._result_cache.clear()
+        """Clear the cache."""
+
+        self.cache.clear()
 
     def has(self, policy: Policy, payload: dict) -> bool:
+        """Check if a cache entry exists for a policy and payload."""
+
         cache_key = self._build_cache_key(policy, payload)
-        return cache_key in self._result_cache
+        return cache_key in self.cache
 
     def add(
         self,
@@ -99,20 +159,26 @@ class PolicyCache:
         message: str | None = None,
         ttl: int | None = None,
     ) -> PolicyCacheEntry:
+        """Add a cache entry for a policy and payload."""
+
         cache_key = self._build_cache_key(policy, payload)
         cache_entry = self._build_cache_entry(
             rule, action, select, selection, message, ttl or self.ttl
         )
-        self._result_cache[cache_key] = cache_entry
+        self.cache[cache_key] = cache_entry
         return cache_entry
 
     def remove(self, policy: Policy, payload: dict) -> PolicyCacheEntry | None:
+        """Remove a cache entry for a policy and payload."""
+
         cache_key = self._build_cache_key(policy, payload)
-        return self._result_cache.pop(cache_key, None)
+        return self.cache.pop(cache_key, None)
 
     def get(self, policy: Policy, payload: dict) -> PolicyCacheEntry | None:
+        """Get a cache entry for a policy and payload."""
+
         cache_key = self._build_cache_key(policy, payload)
-        cache_entry = self._result_cache.get(cache_key)
+        cache_entry = self.cache.get(cache_key)
         if cache_entry is None:
             return None
 
@@ -120,7 +186,7 @@ class PolicyCache:
         cache_entry_timestamp = cache_entry.get("timestamp")
         if cache_entry_ttl is not None and cache_entry_timestamp is not None:
             if time.time() - cache_entry_timestamp > cache_entry_ttl:
-                self._result_cache.pop(cache_key)
+                self.cache.pop(cache_key)
                 return None
 
         return cache_entry

--- a/src/madi/cache.py
+++ b/src/madi/cache.py
@@ -1,0 +1,126 @@
+import time
+from hashlib import sha1
+from io import BufferedReader, BufferedWriter
+from pathlib import Path
+from typing import Literal, NotRequired, TypedDict
+
+from attr import define, field
+from msgspec import json
+
+from madi.types import Policy, PolicyAction, PolicyRule
+
+type FingerprintPolicy = Literal["fast", "full"]
+DEFAULT_FINGERPRINT_POLICY: FingerprintPolicy = "fast"
+
+
+class PolicyCacheEntry(TypedDict):
+    rule: PolicyRule
+    action: PolicyAction
+    select: NotRequired[str]
+    selection: NotRequired[dict]
+    message: NotRequired[str]
+    ttl: NotRequired[int]
+    timestamp: NotRequired[float]
+
+
+@define
+class PolicyCache:
+    ttl: int | None = field(default=None)
+    fingerprint_policy: FingerprintPolicy = field(default=DEFAULT_FINGERPRINT_POLICY)
+    _result_cache: dict[str, PolicyCacheEntry] = field(factory=dict, repr=False, init=False)
+
+    @classmethod
+    def from_file(
+        cls,
+        file_io: BufferedReader,
+        ttl: int | None = None,
+        fingerprint_policy: FingerprintPolicy = DEFAULT_FINGERPRINT_POLICY,
+    ) -> "PolicyCache":
+        cache = cls(ttl=ttl, fingerprint_policy=fingerprint_policy)
+        cache._result_cache = json.decode(file_io.read())
+        return cache
+
+    def to_file(self, file_io: BufferedWriter):
+        file_io.write(json.encode(self._result_cache))
+
+    def to_filepath(self, filepath: Path):
+        with filepath.open("wb") as file_io:
+            file_io.write(json.encode(self._result_cache))
+
+    def _build_policy_fingerprint(self, policy: Policy) -> bytes:
+        if self.fingerprint_policy == "full":
+            return sha1(json.encode(policy, order="sorted")).digest()
+
+        return sha1(
+            json.encode([policy["uid"], sorted([rule["uid"] for rule in policy["rules"]])])
+        ).digest()
+
+    def _build_cache_key(self, policy: Policy, payload: dict) -> str:
+        return sha1(
+            self._build_policy_fingerprint(policy) + json.encode(payload, order="sorted")
+        ).hexdigest()
+
+    def _build_cache_entry(
+        self,
+        rule: PolicyRule,
+        action: PolicyAction,
+        select: str | None = None,
+        selection: dict | None = None,
+        message: str | None = None,
+        ttl: int | None = None,
+    ) -> PolicyCacheEntry:
+        cache_entry: PolicyCacheEntry = {"rule": rule, "action": action}
+        if select is not None and selection is not None:
+            cache_entry = {**cache_entry, "select": select, "selection": selection}
+
+        if message is not None:
+            cache_entry = {**cache_entry, "message": message}
+
+        if ttl is not None:
+            cache_entry = {**cache_entry, "ttl": ttl, "timestamp": time.time()}
+
+        return cache_entry
+
+    def clear(self):
+        self._result_cache.clear()
+
+    def has(self, policy: Policy, payload: dict) -> bool:
+        cache_key = self._build_cache_key(policy, payload)
+        return cache_key in self._result_cache
+
+    def add(
+        self,
+        policy: Policy,
+        payload: dict,
+        rule: PolicyRule,
+        action: PolicyAction,
+        select: str | None = None,
+        selection: dict | None = None,
+        message: str | None = None,
+        ttl: int | None = None,
+    ) -> PolicyCacheEntry:
+        cache_key = self._build_cache_key(policy, payload)
+        cache_entry = self._build_cache_entry(
+            rule, action, select, selection, message, ttl or self.ttl
+        )
+        self._result_cache[cache_key] = cache_entry
+        return cache_entry
+
+    def remove(self, policy: Policy, payload: dict) -> PolicyCacheEntry | None:
+        cache_key = self._build_cache_key(policy, payload)
+        return self._result_cache.pop(cache_key, None)
+
+    def get(self, policy: Policy, payload: dict) -> PolicyCacheEntry | None:
+        cache_key = self._build_cache_key(policy, payload)
+        cache_entry = self._result_cache.get(cache_key)
+        if cache_entry is None:
+            return None
+
+        cache_entry_ttl = cache_entry.get("ttl")
+        cache_entry_timestamp = cache_entry.get("timestamp")
+        if cache_entry_ttl is not None and cache_entry_timestamp is not None:
+            if time.time() - cache_entry_timestamp > cache_entry_ttl:
+                self._result_cache.pop(cache_key)
+                return None
+
+        return cache_entry

--- a/src/madi/cache.py
+++ b/src/madi/cache.py
@@ -24,7 +24,7 @@ The fingerprint policy determines how much information is included in the finger
 FINGERPRINT_POLICIES: set[FingerprintPolicy] = {"fast", "full"}
 """The set of all available fingerprint policies."""
 
-DEFAULT_FINGERPRINT_POLICY: FingerprintPolicy = "fast"
+DEFAULT_FINGERPRINT_POLICY: FingerprintPolicy = "full"
 """The default fingerprint policy."""
 
 

--- a/src/madi/constants.py
+++ b/src/madi/constants.py
@@ -8,10 +8,15 @@ POLICY_META_SCHEMA_V1 = {
     "definitions": {
         "rule": {
             "type": "object",
-            "required": ["ref", "action", "select", "schema"],
+            "required": ["ref", "uid", "action", "select", "schema"],
             "properties": {
                 "ref": {
                     "description": "A identifying reference to this rule; preferably a unique identifier.",
+                    "type": "string",
+                    "minLength": 1,
+                },
+                "uid": {
+                    "description": "A unique identifier for this rule; preferably a UUID.",
                     "type": "string",
                     "minLength": 1,
                 },
@@ -41,7 +46,7 @@ POLICY_META_SCHEMA_V1 = {
         }
     },
     "type": "object",
-    "required": ["ref", "rules"],
+    "required": ["ref", "uid", "rules"],
     "properties": {
         "v": {
             "description": "The version identifier of the policy schema.",
@@ -50,6 +55,11 @@ POLICY_META_SCHEMA_V1 = {
         },
         "ref": {
             "description": "A identifying reference to this policy; preferably a unique identifier.",
+            "type": "string",
+            "minLength": 1,
+        },
+        "uid": {
+            "description": "A unique identifier for this policy; preferably a UUID.",
             "type": "string",
             "minLength": 1,
         },

--- a/src/madi/policy.py
+++ b/src/madi/policy.py
@@ -149,7 +149,12 @@ def validate_policy(
                 raise err
 
 
-def validate_policy_file(filepath: PathLike[str], payload: dict, raise_allowed: bool = False):
+def validate_policy_file(
+    filepath: PathLike[str],
+    payload: dict,
+    raise_allowed: bool = False,
+    cache: PolicyCache | None = None,
+):
     """Validate a policy file against a payload.
 
     This function reads a policy file from the given path and validates it against the provided
@@ -162,7 +167,7 @@ def validate_policy_file(filepath: PathLike[str], payload: dict, raise_allowed: 
 
     policy = json.decode(filepath.read_bytes())
     if is_valid_policy(policy):
-        validate_policy(policy, payload, raise_allowed=raise_allowed)
+        validate_policy(policy, payload, raise_allowed=raise_allowed, cache=cache)
 
 
 def validate_policy_dir(
@@ -171,6 +176,7 @@ def validate_policy_dir(
     deep: bool = False,
     suffix: str = POLICY_SUFFIX,
     raise_allowed: bool = False,
+    cache: PolicyCache | None = None,
 ):
     """Validate all policy files in a directory against a payload.
 
@@ -186,4 +192,4 @@ def validate_policy_dir(
         if not policy_path.is_file():
             continue
 
-        validate_policy_file(policy_path, payload, raise_allowed=raise_allowed)
+        validate_policy_file(policy_path, payload, raise_allowed=raise_allowed, cache=cache)

--- a/src/madi/policy.py
+++ b/src/madi/policy.py
@@ -7,6 +7,7 @@ import jsonschema
 from jmespath.exceptions import EmptyExpressionError, ParseError
 from msgspec import json
 
+from madi.cache import PolicyCache
 from madi.constants import DEFAULT_POLICY_META_SCHEMA, POLICY_META_SCHEMAS, POLICY_SUFFIX
 from madi.errors import AllowedPolicy, DeniedPolicy, InvalidPolicy
 from madi.types import Policy, PolicyRule
@@ -53,7 +54,12 @@ def is_valid_policy(policy: dict | Policy) -> TypeGuard[Policy]:
         raise InvalidPolicy("Policy validation failed", policy) from err
 
 
-def validate_policy_rule(policy: Policy, rule: PolicyRule, payload: dict):
+def validate_policy_rule(
+    policy: Policy,
+    rule: PolicyRule,
+    payload: dict,
+    cache: PolicyCache | None = None,
+):
     """Validate a policy rule against a payload.
 
     This function validates a policy rule against a given payload. It uses JMESPath to query
@@ -66,9 +72,10 @@ def validate_policy_rule(policy: Policy, rule: PolicyRule, payload: dict):
     selection = jmespath.search(select, payload)
     if selection is None:
         if strict:
-            raise DeniedPolicy.from_policy(
-                policy, rule, f"Rule select returned nothing, {select!r}"
-            )
+            message = f"Rule select returned nothing, {select!r}"
+            if cache is not None:
+                cache.add(policy, payload, rule, "DENY", message)
+            raise DeniedPolicy.from_policy(policy, rule, message)
 
         return
 
@@ -76,16 +83,28 @@ def validate_policy_rule(policy: Policy, rule: PolicyRule, payload: dict):
         jsonschema.validate(selection, rule["schema"])
     except jsonschema.ValidationError as err:
         if strict:
+            if cache is not None:
+                cache.add(policy, payload, rule, "DENY")
             raise DeniedPolicy.from_policy(policy, rule) from err
 
         return
 
-    raise (DeniedPolicy if rule["action"] == "DENY" else AllowedPolicy).from_query(
-        policy, rule, select, selection
-    )
+    try:
+        raise (DeniedPolicy if rule["action"] == "DENY" else AllowedPolicy).from_query(
+            policy, rule, select, selection
+        )
+    except (DeniedPolicy, AllowedPolicy):
+        if cache is not None:
+            cache.add(policy, payload, rule, rule["action"], select, selection)
+        raise
 
 
-def validate_policy(policy: Policy, payload: dict, raise_allowed: bool = False):
+def validate_policy(
+    policy: Policy,
+    payload: dict,
+    raise_allowed: bool = False,
+    cache: PolicyCache | None = None,
+):
     """Validate each rule in a policy against a payload.
 
     This will raise a `DeniedPolicy` exception on the first rule that fails. If no rule fails,
@@ -93,9 +112,38 @@ def validate_policy(policy: Policy, payload: dict, raise_allowed: bool = False):
     it will return `None`.
     """
 
+    if cache is not None:
+        cache_result = cache.get(policy, payload)
+        if cache_result is not None:
+            if cache_result["action"] == "DENY":
+                if "select" in cache_result and "selection" in cache_result:
+                    raise DeniedPolicy.from_query(
+                        policy,
+                        cache_result["rule"],
+                        cache_result["select"],
+                        cache_result["selection"],
+                    )
+                raise DeniedPolicy.from_policy(
+                    policy, cache_result["rule"], cache_result.get("message")
+                )
+            elif cache_result["action"] == "ALLOW":
+                if raise_allowed:
+                    if "select" in cache_result and "selection" in cache_result:
+                        raise AllowedPolicy.from_query(
+                            policy,
+                            cache_result["rule"],
+                            cache_result["select"],
+                            cache_result["selection"],
+                        )
+
+                    raise AllowedPolicy.from_policy(
+                        policy, cache_result["rule"], cache_result.get("message")
+                    )
+                return
+
     for rule in policy["rules"]:
         try:
-            validate_policy_rule(policy, rule, payload)
+            validate_policy_rule(policy, rule, payload, cache=cache)
         except AllowedPolicy as err:
             if raise_allowed:
                 raise err

--- a/src/madi/types.py
+++ b/src/madi/types.py
@@ -1,5 +1,8 @@
 from typing import Literal, NotRequired, TypedDict
 
+type PolicyAction = Literal["ALLOW", "DENY"]
+"""A type alias for policy actions."""
+
 
 class PolicyRule(TypedDict):
     """Defines a policy rule."""
@@ -7,13 +10,16 @@ class PolicyRule(TypedDict):
     ref: str
     """A reference identifier for the rule."""
 
+    uid: str
+    """A unique identifier for the rule."""
+
     strict: NotRequired[bool]
     """If true, the rule is strict and must be enforced."""
 
     description: NotRequired[str]
     """An optional description of the rule."""
 
-    action: Literal["ALLOW", "DENY"]
+    action: PolicyAction
     """The decision to make when the rule is evaluated."""
 
     select: str
@@ -28,6 +34,9 @@ class Policy(TypedDict):
 
     ref: str
     """A reference identifier for the policy."""
+
+    uid: str
+    """A unique identifier for the policy."""
 
     strict: NotRequired[bool]
     """

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -143,5 +143,9 @@ def policy_with_action(
     schema: SearchStrategy[dict] | None = None,
 ) -> Policy:
     return draw(
-        policy(rules=lists(policy_rule(select=select, schema=schema, action=action), min_size=1))
+        policy(
+            rules=lists(
+                policy_rule(select=select, schema=schema, action=action), min_size=1, max_size=3
+            )
+        )
     )

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,296 @@
+import time
+from hashlib import sha1
+from string import hexdigits, printable
+from unittest import mock
+
+from hypothesis import given
+from hypothesis.strategies import dictionaries, integers, none, one_of, sampled_from, text
+from msgspec import json
+
+from madi.cache import (
+    DEFAULT_FINGERPRINT_POLICY,
+    FINGERPRINT_POLICIES,
+    FingerprintPolicy,
+    PolicyCache,
+)
+from madi.types import Policy, PolicyAction
+from tests.strategies import base_type, policy, policy_action
+
+
+def describe_PolicyCache():
+    @given(one_of([none(), integers(min_value=0)]))
+    def it_has_a_ttl_property(ttl: int):
+        assert PolicyCache().ttl is None
+        assert PolicyCache(ttl=ttl).ttl == ttl
+
+    @given(sampled_from(list(FINGERPRINT_POLICIES)))
+    def it_has_a_fingerprint_policy_property(fingerprint_policy: FingerprintPolicy):
+        assert PolicyCache().fingerprint_policy == DEFAULT_FINGERPRINT_POLICY
+        assert (
+            PolicyCache(fingerprint_policy=fingerprint_policy).fingerprint_policy
+            == fingerprint_policy
+        )
+
+    @given(policy(), policy_action())
+    def it_has_a_size_property(policy: Policy, action: PolicyAction):
+        cache = PolicyCache()
+        assert cache.size == 0
+
+        cache.add(policy, {}, policy["rules"][0], action)
+        assert cache.size == 1
+
+    @given(policy(), policy_action())
+    def it_has_a_cache_property(policy: Policy, action: PolicyAction):
+        cache = PolicyCache()
+        assert isinstance(cache.cache, dict)
+        assert len(cache.cache) == 0
+
+        cache.add(policy, {}, policy["rules"][0], action)
+        assert isinstance(cache.cache, dict)
+        assert len(cache.cache) == 1
+
+    def describe_from_file():
+        @given(
+            policy(),
+            policy_action(),
+            text(hexdigits, min_size=40, max_size=40),
+            one_of([none(), integers(min_value=0)]),
+            sampled_from(list(FINGERPRINT_POLICIES)),
+        )
+        def it_loads_a_saved_policy_cache_from_an_open_file(
+            policy: Policy,
+            action: PolicyAction,
+            fingerprint: str,
+            ttl: int | None,
+            fingerprint_policy: FingerprintPolicy,
+        ):
+            with mock.patch(
+                "msgspec.json.decode",
+                return_value={fingerprint: {"rule": policy["rules"][0], "action": action}},
+            ):
+                file_io = mock.MagicMock()
+                cache = PolicyCache.from_file(file_io, ttl, fingerprint_policy)
+
+                file_io.read.assert_called_once()
+                assert cache.size == 1
+                assert cache.cache[fingerprint] == {"rule": policy["rules"][0], "action": action}
+
+    def describe_to_file():
+        @given(
+            policy(),
+            policy_action(),
+            text(hexdigits, min_size=40, max_size=40),
+            one_of([none(), integers(min_value=0)]),
+            sampled_from(list(FINGERPRINT_POLICIES)),
+        )
+        def it_writes_the_policy_cache_to_an_open_file(
+            policy: Policy,
+            action: PolicyAction,
+            fingerprint: str,
+            ttl: int | None,
+            fingerprint_policy: FingerprintPolicy,
+        ):
+            file_io = mock.MagicMock()
+            cache = PolicyCache(ttl=ttl, fingerprint_policy=fingerprint_policy)
+            cache.cache[fingerprint] = {"rule": policy["rules"][0], "action": action}
+
+            cache.to_file(file_io)
+            file_io.write.assert_called_once_with(json.encode(cache.cache))
+
+    def describe_build_policy_fingerprint():
+        @given(policy())
+        def it_builds_a_full_fingerprint(policy: Policy):
+            # This test is just a validation of the implementation as we want to ensure that the
+            # fingerprint logic is consistent
+            cache = PolicyCache(fingerprint_policy="full")
+            assert (
+                cache._build_policy_fingerprint(policy)
+                == sha1(json.encode(policy, order="sorted")).digest()
+            )
+
+        @given(policy())
+        def it_builds_a_fast_fingerprint(policy: Policy):
+            # This test is just a validation of the implementation as we want to ensure that the
+            # fingerprint logic is consistent
+            cache = PolicyCache(fingerprint_policy="fast")
+            assert (
+                cache._build_policy_fingerprint(policy)
+                == sha1(
+                    json.encode([policy["uid"], sorted([rule["uid"] for rule in policy["rules"]])])
+                ).digest()
+            )
+
+    def describe_build_cache_key():
+        @given(policy(), dictionaries(min_size=1, keys=text(printable), values=base_type()))
+        def it_builds_a_cache_key(policy: Policy, payload: dict):
+            # This test is just a validation of the implementation as we want to ensure that the
+            # cache key logic is consistent
+            cache = PolicyCache()
+            assert (
+                cache._build_cache_key(policy, payload)
+                == sha1(
+                    cache._build_policy_fingerprint(policy) + json.encode(payload, order="sorted")
+                ).hexdigest()
+            )
+
+    def describe_build_cache_entry():
+        @given(policy(), policy_action())
+        def it_builds_a_cache_entry_with_a_rule_and_action(policy: Policy, action: PolicyAction):
+            cache = PolicyCache()
+            cache_entry = cache._build_cache_entry(policy["rules"][0], action)
+            assert cache_entry["rule"] == policy["rules"][0]
+            assert cache_entry["action"] == action
+
+        @given(
+            policy(),
+            policy_action(),
+            text(printable, min_size=1),
+            dictionaries(
+                min_size=1,
+                max_size=5,
+                keys=text(printable, min_size=1),
+                values=base_type(),
+            ),
+        )
+        def it_builds_a_cache_entry_with_a_select_and_selection(
+            policy: Policy, action: PolicyAction, select: str, selection: dict
+        ):
+            cache = PolicyCache()
+            cache_entry = cache._build_cache_entry(
+                policy["rules"][0],
+                action,
+                select,
+                selection,
+            )
+
+            assert cache_entry.get("select") == select
+            assert cache_entry.get("selection") == selection
+
+        @given(policy(), policy_action(), text(printable))
+        def it_builds_a_cache_entry_with_a_message(
+            policy: Policy, action: PolicyAction, message: str
+        ):
+            cache = PolicyCache()
+            cache_entry = cache._build_cache_entry(policy["rules"][0], action, message=message)
+            assert cache_entry.get("message") == message
+
+        @given(policy(), policy_action(), integers(min_value=1), integers(min_value=0))
+        def it_builds_a_cache_entry_with_a_ttl_and_timestamp(
+            policy: Policy, action: PolicyAction, ttl: int, timestamp: int
+        ):
+            cache = PolicyCache()
+            with mock.patch("time.time", return_value=timestamp):
+                cache_entry = cache._build_cache_entry(policy["rules"][0], action, ttl=ttl)
+
+            assert cache_entry.get("ttl") == ttl
+            assert cache_entry.get("timestamp") == timestamp
+
+    def describe_clear():
+        @given(policy(), policy_action())
+        def it_clears_the_cache(policy: Policy, action: PolicyAction):
+            cache = PolicyCache()
+            cache.add(policy, {}, policy["rules"][0], action)
+            assert cache.size == 1
+
+            cache.clear()
+            assert cache.size == 0
+
+    def describe_has():
+        @given(policy(), policy_action())
+        def it_returns_true_when_a_cache_entry_exists(policy: Policy, action: PolicyAction):
+            cache = PolicyCache()
+            assert not cache.has(policy, {})
+
+            cache.add(policy, {}, policy["rules"][0], action)
+            assert cache.has(policy, {})
+
+        @given(policy(), policy_action())
+        def it_returns_false_when_no_cache_entry_exists(policy: Policy, action: PolicyAction):
+            cache = PolicyCache()
+            assert not cache.has(policy, {})
+
+    def describe_add():
+        @given(
+            policy(),
+            policy_action(),
+            one_of(text(printable), none()),
+            one_of(dictionaries(min_size=1, keys=text(printable), values=base_type()), none()),
+            one_of(text(printable), none()),
+            one_of(integers(min_value=1), none()),
+        )
+        def it_adds_a_cache_entry(
+            policy: Policy,
+            action: PolicyAction,
+            select: str | None,
+            selection: dict | None,
+            message: str | None,
+            ttl: int | None,
+        ):
+            cache = PolicyCache()
+            cache_entry = cache.add(
+                policy, {}, policy["rules"][0], action, select, selection, message, ttl
+            )
+            assert cache_entry["rule"] == policy["rules"][0]
+            assert cache_entry["action"] == action
+
+            if select is not None and selection is not None:
+                assert cache_entry.get("select") == select
+                assert cache_entry.get("selection") == selection
+
+            assert cache_entry.get("message") == message
+            assert cache_entry.get("ttl") == ttl
+            assert cache.size == 1
+
+    def describe_remove():
+        @given(policy(), policy_action())
+        def it_removes_and_returns_a_cache_entry(policy: Policy, action: PolicyAction):
+            cache = PolicyCache()
+            cache.add(policy, {}, policy["rules"][0], action)
+            assert cache.size == 1
+
+            cache_entry = cache.remove(policy, {})
+            assert cache_entry is not None
+            assert cache_entry["rule"] == policy["rules"][0]
+            assert cache_entry["action"] == action
+            assert cache.size == 0
+
+        @given(policy())
+        def it_returns_none_when_no_cache_entry_exists(policy: Policy):
+            cache = PolicyCache()
+            assert cache.remove(policy, {}) is None
+
+    def describe_get():
+        @given(policy())
+        def it_returns_none_when_no_cache_entry_exists(policy: Policy):
+            cache = PolicyCache()
+            assert cache.get(policy, {}) is None
+
+        @given(
+            policy(),
+            policy_action(),
+            integers(min_value=1, max_value=999_999),
+            integers(min_value=0, max_value=999_999),
+        )
+        def it_returns_none_when_the_ttl_has_expired(
+            policy: Policy, action: PolicyAction, ttl: int, ttl_offset: int
+        ):
+            cache = PolicyCache()
+            with mock.patch("time.time", return_value=(time.time() - ttl - ttl_offset)):
+                cache.add(policy, {}, policy["rules"][0], action, ttl=ttl)
+                assert cache.size == 1
+
+            cache_entry = cache.get(policy, {})
+            assert cache_entry is None
+            assert cache.size == 0
+
+        @given(policy(), policy_action())
+        def it_returns_the_cached_entry(policy: Policy, action: PolicyAction):
+            cache = PolicyCache()
+            cache.add(policy, {}, policy["rules"][0], action)
+            assert cache.size == 1
+
+            cache_entry = cache.get(policy, {})
+            assert cache_entry is not None
+            assert cache_entry["rule"] == policy["rules"][0]
+            assert cache_entry["action"] == action
+            assert cache.size == 1


### PR DESCRIPTION
We needed to not cold-start the evaluation of policies every time the service that ran policy validation executed. Technically we can cache the result of a policy evaluation given that the policy structure and the payload structure hasn't changed. So the default `full` cache fingerprinting method will simply checksum the entire policy definition to ensure we are generating cache keys that are valid.

We could speed this up even further by only looking at a unique identifier on the policy and it's rules. This is implemented as the `fast` fingerprint policy for the cache. To support faster policy caching a new `uid` field is being added to the definition of policy and policy rules. This `uid` is intended to uniquely define the current `select` and `schema` of a policy rule. If `select` or `schema` is changed, the cache expects that the `uid` will update as well. **This is wholly the responsibility of the policy creator to update, we don't have any guarantees false positive cache hits will not occur if this `uid` is not updated when either `select` or `schema` are updated.**